### PR TITLE
Posibilidad de obtener las promesas que afectan las sugerencias

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ const autocompleter = new Autocompleter(
 
   - suggestions: `String` to be searched.
 
+#### getSuggestionPromises(suggestion)
+
+- Some suggestions getted in the callback *onSuggestions* are affected by promises, these promises can be obtained using this method.
+
+
 #### removeSuggester(suggesterName)
 
 - Removes a suggester from the autocompleter. This suggester will still be a valid one, but the autocompleter won't take it into account when updating suggestions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usig-gcba/autocompleter",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Librería que devuelve una lista de sugerencias dado un texto determinado.",
   "main": "lib/Autocompleter.min.js",
   "scripts": {

--- a/src/suggesters/Suggester.js
+++ b/src/suggesters/Suggester.js
@@ -7,24 +7,52 @@ const defaults = {
   maxRetries: 5,
   maxSuggestions: 10
 };
-
+const suggestionsPromises = new Map()
 export default class Suggester {
   constructor(name, options) {
     this.name = name;
     this.options = Object.assign({}, defaults, options);
     this.status = 'done';
     this.inputTimer = null;
+    this.suggestionsPromises = suggestionsPromises
+  }
+
+  /**
+   * Retorna una array de promises del suggestion recibido como parámetro
+   * @param {Object} suggestion uno de los objetos retornado por getSuggestions
+   */
+  static getSuggestionPromises(suggestion) {
+    return suggestionsPromises.get(suggestion) || []
+  }
+  /**
+   * Este método deber ser 
+   * @param {*} suggestion 
+   * @param {*} promise 
+   */
+  addSuggestionPromise(suggestion, promise){
+    if(!suggestionsPromises.has(suggestion)){
+      suggestionsPromises.set(suggestion, [promise])
+    }else{
+      suggestionsPromises.get(suggestion).push(promise)
+    }
   }
 
   /**
    * Dado un string, realiza una busqueda de sugerencias y llama al callback con las
    * opciones encontradas.
+   * En algunos casos los objetos retornados tienen data incompleta que serán cargadas con posterioridad
+   * Si se desea esperar por esta carga puede hacer un Pomise.all del array retornado por getSuggestionPromises
    * @param {String} text Texto de input
    * @param {Function} callback Funcion que es llamada con la lista de sugerencias
    * @param {Integer} maxSuggestions (optional) Maximo numero de sugerencias a devolver
    */
   getSuggestions(text, callback, maxSuggestions) {
-    throw new this.MethodNotImplemented();
+    /*
+    * En algunos casos puede ser util hacer fetch de datos que serán utilizados con posterioridad
+    * en estos casos se pueden almacenar en SuggestionsPromises el objeto suggestion como key y un array de promises como su value
+    * El método getSuggestionPromises retorna este array de promises
+    */
+     throw new this.MethodNotImplemented();
   }
 
   /**

--- a/src/suggesters/SuggesterDirecciones.js
+++ b/src/suggesters/SuggesterDirecciones.js
@@ -84,7 +84,19 @@ export default class SuggesterDirecciones extends Suggester {
       let dirs = this.options.normalizadorDirecciones.normalizar(text, maxSug);
       dirs = dirs.map((d) => {
         d.descripcion = 'Ciudad Autónoma de Buenos Aires';
-        this.getLatLng2(d).then((r) => {
+        const suggestion = {
+          title: d.nombre,
+          subTitle: d.descripcion,
+          type: d.tipo,
+          category: d.type,
+          suggesterName: this.name,
+          data: d
+        }
+        const latLng2 = this.getLatLng2(d)
+        const latLng3 = this.getLatLng3(d)
+        this.addSuggestionPromise(suggestion, latLng2)
+        this.addSuggestionPromise(suggestion, latLng3)
+        latLng2.then((r) => {
           if (
             r['direccionesNormalizadas'] &&
             r['direccionesNormalizadas'][0] &&
@@ -98,19 +110,12 @@ export default class SuggesterDirecciones extends Suggester {
             return d.coordenadas;
           }
         });
-        this.getLatLng3(d).then((r) => {
+        latLng3.then((r) => {
           // Para que devuelva estos datos hay que indicarle una altura a la direccion
           if (r['smp']) d.smp = r['smp'];
           return d.smp;
         });
-        return {
-          title: d.nombre,
-          subTitle: d.descripcion,
-          type: d.tipo,
-          category: d.type,
-          suggesterName: this.name,
-          data: d
-        };
+        return suggestion;
       });
       callback(dirs, text, this.name);
     } catch (error) {

--- a/src/suggesters/SuggesterDireccionesAMBA.js
+++ b/src/suggesters/SuggesterDireccionesAMBA.js
@@ -70,8 +70,18 @@ export default class SuggesterDireccionesAMBA extends Suggester {
     let maxSug = maxSuggestions !== undefined ? maxSuggestions : this.options.maxSuggestions;
     const midCallback = (results) => {
       results = results.map((d, i) => {
+        const suggestion = {
+          title: d.nombre,
+          subTitle: d.descripcion,
+          type: d.tipo,
+          category: d.tipo,
+          suggesterName: this.name,
+          data: d
+        }
         if (d.tipo === 'DIRECCION') {
-          this.getLatLng2(d).then((r) => {
+          const latLng2 = this.getLatLng2(d)
+          this.addSuggestionPromise(suggestion, latLng2)
+          latLng2.then((r) => {
             if (
               r['direccionesNormalizadas'] &&
               r['direccionesNormalizadas'][0] &&
@@ -86,14 +96,7 @@ export default class SuggesterDireccionesAMBA extends Suggester {
             }
           });
         }
-        return {
-          title: d.nombre,
-          subTitle: d.descripcion,
-          type: d.tipo,
-          category: d.tipo,
-          suggesterName: this.name,
-          data: d
-        };
+        return suggestion;
       });
       callback(results, text, this.name);
     };

--- a/src/suggesters/SuggesterLugares.js
+++ b/src/suggesters/SuggesterLugares.js
@@ -84,7 +84,17 @@ export default class SuggesterLugares extends Suggester {
     this.lastRequest = mkRequest(data, defaults.server, {}).then(
       res => {
         const results = res.instancias.map((d) => {
-          this.getLatLng2(d).then((r) => {
+          const suggestion = {
+            title: d.nombre,
+            subTitle: d.clase,
+            type: 'LUGAR',
+            idEpok: d.id,
+            suggesterName: this.name,
+            data: d
+          }
+          const latLng2 = this.getLatLng2(d)
+          this.addSuggestionPromise(suggestion, latLng2)
+          latLng2.then((r) => {
             if ( r.ubicacion ) {
               d.coordenadas = {
                 x: parseFloat(r.ubicacion.centroide.split('(', 2)[1]),
@@ -94,14 +104,7 @@ export default class SuggesterLugares extends Suggester {
               return d.coordenadas;
             }
           });
-          return {
-            title: d.nombre,
-            subTitle: d.clase,
-            type: 'LUGAR',
-            idEpok: d.id,
-            suggesterName: this.name,
-            data: d
-          };
+          return suggestion;
         });
         callback(results, text, this.name);
       },


### PR DESCRIPTION
Al obtener estas promesas es posible aguardar por las coordendas generadas en el método getSuggestions del suggester Direcciones.

Este pr incluye README.md y demo React. Sería útil que quien utilice Angular agregue el uso del método Suggester.getSuggestionPromises